### PR TITLE
Unexpected behaviour when RelayoutItem has inline children

### DIFF
--- a/style/css/relayout-item.css
+++ b/style/css/relayout-item.css
@@ -5,10 +5,6 @@
   box-sizing: border-box;
 }
 
-.relayout__item > * {
-  width: 100%;
-}
-
 /**
  * Apply the gutter based on the parent's class
  */

--- a/style/sass/relayout-item.scss
+++ b/style/sass/relayout-item.scss
@@ -5,10 +5,6 @@
   box-sizing: border-box;
 }
 
-.relayout__item > * {
-  width: 100%;
-}
-
 /**
  * Apply the gutter based on the parent's class
  */


### PR DESCRIPTION
Rendering the following tree:

``` jsx
<RelayoutWrapper>
  <Relayout>
    <RelayoutItem>
      <span>
        foo
      </span>
      <span>
        bar
      </span>
    </RelayoutItem>
  </Relayout>
</RelayoutWrapper>
```

Forces the children to be 100%:

``` css
.relayout__item > * {
    width: 100%;
}
```

But that's unexpected, since the elements are `inline` ones.
